### PR TITLE
Fix typo that prevents Consumable player from displaying.

### DIFF
--- a/consumable-htb.js
+++ b/consumable-htb.js
@@ -275,7 +275,7 @@ function ConsumableHtb(configs) {
                 + '</div>'
                 + '<div class="' + curReturnParcel.xSlotRef.unitName + '"></div>'
                 + '<script src="https://yummy.consumable.com/' + curReturnParcel.xSlotRef.unitId
-                + '/' + curReturnParcel.xSlotName.unitName + '/widget/unit.js?cb=' + cb + '" async></script>';
+                + '/' + curReturnParcel.xSlotRef.unitName + '/widget/unit.js?cb=' + cb + '" async></script>';
 
             /* The dealId if applicable for this slot. */
             var bidDealId = '';


### PR DESCRIPTION
This PR fixes a typo that caused the wrong URL to be generated for the Consumable script.