### PR TITLE
Add missing parameters to bid request; cleanup

### DIFF
--- a/consumable-htb.js
+++ b/consumable-htb.js
@@ -12,6 +12,7 @@ var Size = require('size.js');
 var SpaceCamp = require('space-camp.js');
 var System = require('system.js');
 var Network = require('network.js');
+var Utilities = require('utilities.js');
 
 var RenderService;
 
@@ -210,9 +211,7 @@ function ConsumableHtb(configs) {
                         divName: parcel.xSlotName,
                         adTypes: parcel.xSlotRef.sizes
                             .map(sizeToAdType)
-                            .filter(function (adType) {
-                                return typeof adType === 'number';
-                            })
+                            .filter(Utilities.isNumber)
                     };
                 }),
                 time: System.now(),

--- a/consumable-htb.js
+++ b/consumable-htb.js
@@ -208,6 +208,8 @@ function ConsumableHtb(configs) {
                         networkId: parcel.xSlotRef.networkId,
                         siteId: parcel.xSlotRef.siteId,
                         zoneIds: parcel.xSlotRef.zoneIds,
+                        unitId: parcel.xSlotRef.unitId,
+                        unitName: parcel.xSlotRef.unitName,
                         divName: parcel.xSlotName,
                         adTypes: parcel.xSlotRef.sizes
                             .map(sizeToAdType)


### PR DESCRIPTION
 * Add missing `unitId` and `unitName` parameters to bid request.
 * Use `Utilities.isNumber` in preference to `typeof x === "number"`.